### PR TITLE
Use consistent starter scaffolds across blueprints

### DIFF
--- a/src/asciidoc/docs/blueprints/customVCC.adoc
+++ b/src/asciidoc/docs/blueprints/customVCC.adoc
@@ -30,12 +30,21 @@ For an overview, see <<build-custom-vcc#>>.
 Remix an existing web application on Koji that implements basic elements of your favorite framework.
 
 .React
-https://withkoji.com/templates/seane/simple-react-scaffold-remix-[Simple React scaffold]
+https://withkoji.com/templates/seane/simple-react-scaffold[Simple React scaffold]
 
 .Vanilla JS
-https://withkoji.com/templates/JamesHole/vanilla-js-scaffold-with-vccs[Vanilla JS scaffold]
+https://withkoji.com/templates/JamesHole/vanilla-js-scaffold[Vanilla JS scaffold]
 
 === Install the packages
+
+Install @withkoji/vcc to expose Visual Customization Controls (VCCs), dynamically update custom values, and display your template correctly in the Koji feed.
+
+[source,bash]
+----
+npm install --save @withkoji/vcc
+----
+
+include::../_includes/note-start-watcher.adoc[tags=*]
 
 Install @withkoji/custom-vcc-sdk to enable custom VCC functionality, such as loading and saving the VCC value from Koji.
 

--- a/src/asciidoc/docs/blueprints/voteCounter.adoc
+++ b/src/asciidoc/docs/blueprints/voteCounter.adoc
@@ -31,10 +31,10 @@ See the <<withkoji-database-package#>> package reference.
 Remix an existing web application on Koji that implements basic elements of your favorite framework.
 
 .React
-https://withkoji.com/~seane/simple-react-scaffold[Simple React scaffold]
+https://withkoji.com/templates/seane/simple-react-scaffold[Simple React scaffold]
 
 .Vanilla JS
-https://withkoji.com/~JamesHole/vanilla-js-instant-remix-scaffold[Vanilla JS scaffold]
+https://withkoji.com/templates/JamesHole/vanilla-js-scaffold[Vanilla JS scaffold]
 
 === Add the backend service
 


### PR DESCRIPTION
@rasienko as per my comments on discord, updated the blueprints to all use the same starter scaffold in both Vanilla and React. Also changed the links to point to the template info page rather than the preview page just because it seems easier for developers.