### PR TITLE
Design nitpicks

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -138,7 +138,6 @@ module.exports = {
         attributes: {
           showtitle: true,
           imagesdir: '/images',
-          icons: 'font',
         },
         catalog_assets: true,
         converterFactory: TemplateConverter,

--- a/src/asciidoc/docs/getting-started/developer.adoc
+++ b/src/asciidoc/docs/getting-started/developer.adoc
@@ -17,8 +17,6 @@ You can develop templates for any type of web application, including interactive
 
 <<templates#, Learn more about Koji templates>>
 
-image::Koji-developer.png[Koji development process]
-
 Your templates can empower artists, influencers, brands, and content creators with new, interactive ways to reach their audiences and express themselves.
 With the ability to create and share remixable, interactive content, the opportunities for creative new experiences are countless.
 We can’t wait to see what YOU make!

--- a/src/asciidoc/docs/getting-started/developer.adoc
+++ b/src/asciidoc/docs/getting-started/developer.adoc
@@ -23,7 +23,7 @@ Your templates can empower artists, influencers, brands, and content creators wi
 With the ability to create and share remixable, interactive content, the opportunities for creative new experiences are countless.
 We can’t wait to see what YOU make!
 
-== What's new icon:bullhorn[]
+== What's new
 
 For a summary of the latest updates to the Koji platform and developer site, check out the <<developer-updates#>>.
 

--- a/src/components/AppBar.js
+++ b/src/components/AppBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'gatsby';
 
-import { BLACK, BLUE, DARK_GRAY, LIGHT_GRAY } from '../constants/colors';
+import { BLACK, DARK_GRAY, LIGHT_GRAY } from '../constants/colors';
 
 import Logo from './Logo';
 import DiscordLogo from './DiscordLogo';

--- a/src/components/AppBar.js
+++ b/src/components/AppBar.js
@@ -33,7 +33,6 @@ const Wrapper = styled.div`
   a {
     font-size: 16px;
     color: ${DARK_GRAY};
-    margin-right: 16px;
     padding: 4px 8px;
     border-radius: 8px;
     text-decoration: none;
@@ -57,31 +56,6 @@ const LogoWrapper = styled.div`
   }
 `;
 
-const Tooltip = styled.div`
-  position: relative;
-  top: -4px;
-  font-size: 12px;
-  font-weight: bold;
-  background: ${BLUE};
-  color: white;
-  padding: 6px;
-  border-radius: 6px;
-  margin-left: 4px;
-
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 9px;
-    left: -12px;
-    width: 0px;
-    height: 0px;
-    border: 6px solid #007aff;
-    border-color: transparent ${BLUE} transparent transparent;
-    z-index: -1;
-  }
-`;
-
 const StyledLink = styled(Link)`
   text-decoration: none;
 
@@ -93,7 +67,7 @@ const StyledLink = styled(Link)`
 const LogoLink = styled(StyledLink)`
   display: flex;
   align-items: center;
-  margin: 8px 0 0 -8px;
+  margin: 4px 0 0 -8px;
 
   a:hover, &:hover {
     background: transparent !important;
@@ -103,7 +77,6 @@ const LogoLink = styled(StyledLink)`
 const SectionLinks = styled.div`
   display: flex;
   align-items: center;
-  margin-left: 32px;
 
   @media screen and (max-width: 768px) {
     display: none;
@@ -125,6 +98,7 @@ const BackLink = styled.a`
 const ExternalLink = styled.a`
   display: flex;
   padding: 0 !important;
+  margin-right: 10px!important;
 
   @media screen and (max-width: 768px) {
     display: none;
@@ -138,6 +112,12 @@ const ExternalLink = styled.a`
     width: 20px;
     height: 20px;
     fill: #a5a5a5;
+  }
+`;
+
+const DiscordLink = styled(ExternalLink)`
+  margin-right: 4px!important;
+  svg {
     margin-top: 4px;
   }
 `;
@@ -149,9 +129,6 @@ const AppBar = ({ navItems }) => (
         <LogoWrapper>
           <Logo />
         </LogoWrapper>
-        <Tooltip>
-          {'for developers'}
-        </Tooltip>
       </LogoLink>
       <SectionLinks>
         {
@@ -168,14 +145,14 @@ const AppBar = ({ navItems }) => (
       >
         <GithubLogo />
       </ExternalLink>
-      <ExternalLink
+      <DiscordLink
         href={'https://discord.com/invite/eQuMJF6'}
         target={'_blank'}
         title={'Join us on Discord'}
         style={{ marginRight: '12px' }}
       >
         <DiscordLogo />
-      </ExternalLink>
+      </DiscordLink>
       <BackLink href={'https://withkoji.com'} style={{ marginRight: 0 }}>
         {'Back to withkoji.com'}
       </BackLink>

--- a/src/components/AppSubBar.js
+++ b/src/components/AppSubBar.js
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { navigate } from '@reach/router';
 
 import SearchIcon from '@material-ui/icons/Search';
+import ArrowIcon from '@material-ui/icons/KeyboardArrowRight';
 
 const Container = styled.div`
   width: 100%;
@@ -11,8 +12,8 @@ const Container = styled.div`
   padding: 0 30px;
   font-size: 14px;
   position: relative;
-  background-color: #f5f5f5;
-  border-bottom: 1px solid #dadee2;
+  background-color: #f4f4f4;
+  border-bottom: 1px solid rgba(0,0,0,0.1);
   display: flex;
   color: #666666;
 `;
@@ -60,7 +61,7 @@ const NavItemDropdown = styled.select`
   max-width: 72px;
 
   &:hover {
-    border: 1px solid #333333;
+    border: 1px solid #111111;
     background: #ffffff;
   }
 `;
@@ -82,7 +83,7 @@ const SectionDropdown = styled.select`
   max-width: 160px;
 
   &:hover {
-    border: 1px solid #333333;
+    border: 1px solid #111111;
     background: #ffffff;
   }
 `;
@@ -105,7 +106,16 @@ const BreadCrumb = styled.div`
 `;
 
 const Crumb = styled.div`
-  margin-right: 12px;
+  margin-right: 6px;
+  display: flex;
+  align-items: center;
+  line-height: 1;
+  font-size: 13px;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
 `;
 
 const SearchWrapper = styled.div`
@@ -113,6 +123,7 @@ const SearchWrapper = styled.div`
   align-items: center;
   margin-right: 8px;
   cursor: pointer;
+  width: 184px;
 
   svg {
     fill: #666666;
@@ -176,11 +187,15 @@ const AppSubBar = ({ location, navItems, onSearchClick }) => {
                 <Crumb>
                   {currentNavItem.name}
                 </Crumb>
-                <Crumb>&gt;</Crumb>
+                <Crumb>
+                  <ArrowIcon />
+                </Crumb>
                 <Crumb>
                   {currentSection.name}
                 </Crumb>
-                <Crumb>&gt;</Crumb>
+                <Crumb>
+                  <ArrowIcon />
+                </Crumb>
                 <Crumb>
                   {currentItem.name}
                 </Crumb>

--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -58,8 +58,8 @@ const SectionHeader = styled.h3`
   margin: 25px auto 8px;
   font-size: 13px;
   text-transform: uppercase;
-  font-weight: 500;
-  color: #333333;
+  font-weight: bold;
+  color: #111111;
 `;
 
 const SectionItems = styled.ul`
@@ -75,11 +75,13 @@ const SectionItem = styled.li`
   background: ${({ style: { isActive } }) => isActive ? BLUE : 'transparent'};
   cursor: pointer;
   border-radius: 2.5px;
-  color: ${({ style: { isActive } }) => isActive ? '#ffffff' : '#333333'};
+  color: ${({ style: { isActive } }) => isActive ? '#ffffff' : '#111111'};
 
   &:hover {
-    background: ${LIGHT_GRAY};
-    color: ${BLUE};
+    ${({ style: { isActive } }) => !isActive && `
+      background: ${LIGHT_GRAY};
+      color: ${BLUE};
+    `}
   }
 `;
 
@@ -88,7 +90,9 @@ const StyledLink = styled(Link)`
   text-decoration: none;
 
   &:hover {
-    color: ${BLUE};
+    ${({ style: { isActive } }) => !isActive && `
+      color: ${BLUE};
+    `}
   }
 `;
 
@@ -104,10 +108,10 @@ const ExternalLink = styled.a`
   font-size: 13px;
   padding: 5px 10px;
   margin: 0 0 0 -10px;
-  background: transparent
+  background: transparent;
   cursor: pointer;
   border-radius: 2.5px;
-  color: #333333;
+  color: #111111;
   text-decoration: none;
 
 
@@ -147,25 +151,6 @@ const LeftNav = ({ location, navItems }) => {
           </Section>
         ))
       }
-      <Divider />
-      <ExternalLink
-        href={'https://withkoji.com/resources/privacy'}
-        target={'blank'}
-      >
-        {'Privacy'}
-      </ExternalLink>
-      <ExternalLink
-        href={'https://withkoji.com/resources/terms'}
-        target={'blank'}
-      >
-        {'Terms of Use'}
-      </ExternalLink>
-      <ExternalLink
-        href={'https://withkoji.com/resources/copyright'}
-        target={'blank'}
-      >
-        {'Copyright'}
-      </ExternalLink>
     </Container>
   );
 };

--- a/src/components/LeftNav.js
+++ b/src/components/LeftNav.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'gatsby';
 
-import { BLACK, BLUE, DARK_GRAY, LIGHT_GRAY } from '../constants/colors';
+import { BLACK, BLUE, LIGHT_GRAY } from '../constants/colors';
 
 const Container = styled.nav`
   width: 246px;
@@ -93,32 +93,6 @@ const StyledLink = styled(Link)`
     ${({ style: { isActive } }) => !isActive && `
       color: ${BLUE};
     `}
-  }
-`;
-
-const Divider = styled.div`
-  width: 100%;
-  height: 1px;
-  background: rgba(0, 0, 0, 0.5);
-  margin: 12px 0;
-`;
-
-const ExternalLink = styled.a`
-  display: block;
-  font-size: 13px;
-  padding: 5px 10px;
-  margin: 0 0 0 -10px;
-  background: transparent;
-  cursor: pointer;
-  border-radius: 2.5px;
-  color: #111111;
-  text-decoration: none;
-
-
-  &:hover {
-    text-decoration: none;
-    background: ${LIGHT_GRAY};
-    color: ${BLUE};
   }
 `;
 

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -18,7 +18,7 @@ const GroupsWrapper = styled.div`
   width: 100%;
   background: #ffffff;
   overflow: auto;
-  color: #333333;
+  color: #111111;
   padding: 16px;
   text-align: left;
   flex: 1 0 auto;

--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -1,11 +1,11 @@
 body {
   margin: 0;
-  font-family: franklin-gothic-urw, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   width: 100vw;
   height: 100vh;
   overflow: auto;
   overflow-x: hidden;
-  color: #333333;
+  color: #111111;
 }
 
 html {

--- a/src/layouts/index.css
+++ b/src/layouts/index.css
@@ -19,5 +19,5 @@ html {
 pre {
   font-family: Menlo, Monaco, "Courier New", monospace;
   border-radius: 4px;
-  font-size: 13px;
+  font-size: 12px;
 }

--- a/src/styles/adoc-boot-readable.css
+++ b/src/styles/adoc-boot-readable.css
@@ -6,7 +6,7 @@ body {
   font-family: Georgia, "Times New Roman", Times, serif;
   font-size: 16px;
   line-height: 1.42857143;
-  color: #333333;
+  color: #111111;
   background-color: #ffffff;
   margin-left: 10%;
   margin-right: 10%;
@@ -124,7 +124,7 @@ blockquote .small {
   display: block;
   font-size: 80%;
   line-height: 1.42857143;
-  color: #333333;
+  color: #111111;
 }
 .attribution:before,
 blockquote footer:before,
@@ -250,7 +250,7 @@ kbd {
   padding: 2px 4px;
   font-size: 90%;
   color: #ffffff;
-  background-color: #333333;
+  background-color: #111111;
   border-radius: 0;
   -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
           box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
@@ -270,7 +270,7 @@ pre {
   line-height: 1.42857143;
   word-break: break-all;
   word-wrap: break-word;
-  color: #333333;
+  color: #111111;
   background-color: #f5f5f5;
   border: 1px solid #cccccc;
   border-radius: 4px;

--- a/src/styles/adoc-koji.css
+++ b/src/styles/adoc-koji.css
@@ -1,8 +1,19 @@
 /* Admonitions */
 .admonitionblock > table { padding: 8px 0; background: none; width: 100%; border-left: 4px solid #bfbfbf;background-color: #f7f7f7; }
-.admonitionblock > table td.icon { text-align: center; width: 12px; vertical-align: top; font-size: 10px; }
+.admonitionblock > table td.icon { 
+    text-align: center;
+    width: 12px;
+    vertical-align: top;
+    font-size: 10px;
+    padding: 5px 6px 0 12px;
+}
 .admonitionblock > table td.icon img { max-width: none; }
-.admonitionblock > table td.icon .title { font-weight: bold; text-transform: uppercase; }
+.admonitionblock > table td.icon .title { 
+    font-weight: bold;
+    text-transform: uppercase;
+    color: #666666;
+    font-size: 12px;
+}
 .admonitionblock > table td.content { padding-left: 4px; padding-right: 40px; color: #404040; line-height: 1.5; font-size: 15px; }
 .admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
 .admonitionblock > table p:first-child { margin-top: 0 !important; }

--- a/src/styles/adoc-koji.css
+++ b/src/styles/adoc-koji.css
@@ -17,7 +17,7 @@
 .listingblock + .admonitionblock, .admonitionblock + .listingblock, .admonitionblock + .admonitionblock { margin-top: 20px; }
 
 /* Code Call outs */
-.conum { display: inline-block; color: white !important; background-color: #404040; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; width: 20px; height: 20px; font-size: 12px; font-weight: bold; line-height: 20px; font-family: Arial, sans-serif; font-style: normal; position: relative; top: -2px; letter-spacing: -1px; user-select: none; }
+.conum { display: inline-block; color: white !important; background-color: #404040; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; width: 20px; height: 20px; font-size: 12px; font-weight: bold; line-height: 20px; font-family: Arial, sans-serif; font-style: normal; position: relative; top: -2px; user-select: none; }
 .conum * { color: white !important; }
 .conum + b { display: none; }
 .conum:after { content: attr(data-value); }
@@ -54,7 +54,7 @@ ol li ul, ol li ol { margin-bottom: 0.625em; }
 .exampleblock:not(.tabbed__tab):not(.tabs) > .content { border-style: solid; border-width: 1px; border-color: #cccccc; margin-bottom: 1.25em; padding: 1.25em; background: #e5e5e5; -webkit-border-radius: 0; border-radius: 0; }
 .exampleblock > .content > :first-child { margin-top: 0; }
 .exampleblock > .content > :last-child { margin-bottom: 0; }
-.exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6, .exampleblock > .content p { color: #333333; }
+.exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6, .exampleblock > .content p { color: #111111; }
 .exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6 { line-height: 1; margin-bottom: 0.625em; }
 .exampleblock > .content h1.subheader, .exampleblock > .content h2.subheader, .exampleblock > .content h3.subheader, .exampleblock > .content .subheader#toctitle, .sidebarblock.exampleblock > .content > .subheader.title, .exampleblock > .content h4.subheader, .exampleblock > .content h5.subheader, .exampleblock > .content h6.subheader { line-height: 1.4; }
 
@@ -63,7 +63,7 @@ ol li ul, ol li ol { margin-bottom: 0.625em; }
 .sidebarblock { border-style: solid; border-width: 1px; border-color: #cccccc; margin-bottom: 1.25em; padding: 1.25em; background: #e5e5e5; -webkit-border-radius: 0; border-radius: 0; }
 .sidebarblock > :first-child { margin-top: 0; }
 .sidebarblock > :last-child { margin-bottom: 0; }
-.sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6, .sidebarblock p { color: #333333; }
+.sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6, .sidebarblock p { color: #111111; }
 .sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6 { line-height: 1; margin-bottom: 0.625em; }
 .sidebarblock h1.subheader, .sidebarblock h2.subheader, .sidebarblock h3.subheader, .sidebarblock .subheader#toctitle, .sidebarblock > .content > .subheader.title, .sidebarblock h4.subheader, .sidebarblock h5.subheader, .sidebarblock h6.subheader { line-height: 1.4; }
 .sidebarblock > .content > .title { color: #4d4d4d; margin-top: 0; line-height: 1.4; }
@@ -106,7 +106,7 @@ table.pyhltable .linenodiv { background-color: transparent !important; padding-r
 .quoteblock { margin: 0 0 1.375em; padding: 0 0 0 1em; border-left: 5px solid #ededed; }
 .quoteblock blockquote { margin: 0 0 1.375em 0; padding: 0 0 0.5625em 0; border: 0; }
 .quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
-.quoteblock .attribution { margin-top: -.25em; padding-bottom: 0.5625em; font-size: 0.8125em; color: #333333; }
+.quoteblock .attribution { margin-top: -.25em; padding-bottom: 0.5625em; font-size: 0.8125em; color: #111111; }
 .quoteblock .attribution br { display: none; }
 .quoteblock .attribution cite { display: block; margin-bottom: 0.625em; }
 

--- a/src/styles/adoc-koji.css
+++ b/src/styles/adoc-koji.css
@@ -1,18 +1,11 @@
 /* Admonitions */
 .admonitionblock > table { padding: 8px 0; background: none; width: 100%; border-left: 4px solid #bfbfbf;background-color: #f7f7f7; }
-.admonitionblock > table td.icon { text-align: center; width: 48px; vertical-align: top; font-size: 10px; }
+.admonitionblock > table td.icon { text-align: center; width: 12px; vertical-align: top; font-size: 10px; }
 .admonitionblock > table td.icon img { max-width: none; }
 .admonitionblock > table td.icon .title { font-weight: bold; text-transform: uppercase; }
 .admonitionblock > table td.content { padding-left: 4px; padding-right: 40px; color: #404040; line-height: 1.5; font-size: 15px; }
 .admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
 .admonitionblock > table p:first-child { margin-top: 0 !important; }
-.admonitionblock td.icon i:before { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
-.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #006699; color: #004c73; }
-.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; font-weight: 400; text-shadow: 1px 1px 2px rgba(255, 215, 0, 0.8); }
-.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
-.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
-.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
-
 
 .listingblock + .admonitionblock, .admonitionblock + .listingblock, .admonitionblock + .admonitionblock { margin-top: 20px; }
 

--- a/src/styles/adoc-koji.css
+++ b/src/styles/adoc-koji.css
@@ -187,7 +187,13 @@ td.hdlist1, td.hdlist2 { vertical-align: top; }
 
 .imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
 .imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
-.imageblock > .title { margin-bottom: 0; }
+.imageblock > .title { 
+    margin-bottom: 0!important;
+    font-size: 12px!important;
+    text-align: center!important;
+    color: #666!important;
+    font-weight: normal!important;
+}
 .imageblock.thumb, .imageblock.th { border-width: 6px; }
 .imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
 

--- a/src/styles/adoc-rocket-panda.css
+++ b/src/styles/adoc-rocket-panda.css
@@ -228,9 +228,9 @@ abbr { text-transform: none; }
 
 /* Blockquotes */
 blockquote { margin: 0 0 1.375em; padding: 0 0 0 1em; border-left: 5px solid #ededed; }
-blockquote cite { display: block; font-size: 0.8125em; color: #333333; }
+blockquote cite { display: block; font-size: 0.8125em; color: #111111; }
 blockquote cite:before { content: "\2014 \0020"; }
-blockquote cite a, blockquote cite a:visited { color: #333333; }
+blockquote cite a, blockquote cite a:visited { color: #111111; }
 
 blockquote, blockquote p { line-height: 1.4; color: #404040; }
 
@@ -363,7 +363,7 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 .exampleblock > .content { border-style: solid; border-width: 1px; border-color: #cccccc; margin-bottom: 1.25em; padding: 1.25em; background: #e5e5e5; -webkit-border-radius: 0; border-radius: 0; }
 .exampleblock > .content > :first-child { margin-top: 0; }
 .exampleblock > .content > :last-child { margin-bottom: 0; }
-.exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6, .exampleblock > .content p { color: #333333; }
+.exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6, .exampleblock > .content p { color: #111111; }
 .exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6 { line-height: 1; margin-bottom: 0.625em; }
 .exampleblock > .content h1.subheader, .exampleblock > .content h2.subheader, .exampleblock > .content h3.subheader, .exampleblock > .content .subheader#toctitle, .sidebarblock.exampleblock > .content > .subheader.title, .exampleblock > .content h4.subheader, .exampleblock > .content h5.subheader, .exampleblock > .content h6.subheader { line-height: 1.4; }
 
@@ -372,7 +372,7 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 .sidebarblock { border-style: solid; border-width: 1px; border-color: #cccccc; margin-bottom: 1.25em; padding: 1.25em; background: #e5e5e5; -webkit-border-radius: 0; border-radius: 0; }
 .sidebarblock > :first-child { margin-top: 0; }
 .sidebarblock > :last-child { margin-bottom: 0; }
-.sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6, .sidebarblock p { color: #333333; }
+.sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6, .sidebarblock p { color: #111111; }
 .sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6 { line-height: 1; margin-bottom: 0.625em; }
 .sidebarblock h1.subheader, .sidebarblock h2.subheader, .sidebarblock h3.subheader, .sidebarblock .subheader#toctitle, .sidebarblock > .content > .subheader.title, .sidebarblock h4.subheader, .sidebarblock h5.subheader, .sidebarblock h6.subheader { line-height: 1.4; }
 .sidebarblock > .content > .title { color: #4d4d4d; margin-top: 0; line-height: 1.4; }
@@ -422,7 +422,7 @@ table.pyhltable .linenodiv { background-color: transparent !important; padding-r
 .quoteblock { margin: 0 0 1.375em; padding: 0 0 0 1em; border-left: 5px solid #ededed; }
 .quoteblock blockquote { margin: 0 0 1.375em 0; padding: 0 0 0.5625em 0; border: 0; }
 .quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
-.quoteblock .attribution { margin-top: -.25em; padding-bottom: 0.5625em; font-size: 0.8125em; color: #333333; }
+.quoteblock .attribution { margin-top: -.25em; padding-bottom: 0.5625em; font-size: 0.8125em; color: #111111; }
 .quoteblock .attribution br { display: none; }
 .quoteblock .attribution cite { display: block; margin-bottom: 0.625em; }
 
@@ -617,7 +617,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 .admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
 .admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
 
-.conum { display: inline-block; color: white !important; background-color: #404040; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; width: 20px; height: 20px; font-size: 12px; font-weight: bold; line-height: 20px; font-family: Arial, sans-serif; font-style: normal; position: relative; top: -2px; letter-spacing: -1px; }
+.conum { display: inline-block; color: white !important; background-color: #404040; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; width: 20px; height: 20px; font-size: 12px; font-weight: bold; line-height: 20px; font-family: Arial, sans-serif; font-style: normal; position: relative; top: -2px; }
 .conum * { color: white !important; }
 .conum + b { display: none; }
 .conum:after { content: attr(data-value); }

--- a/src/styles/dark-code.css
+++ b/src/styles/dark-code.css
@@ -4,7 +4,7 @@
  */
 
 body.darkCode .hljs {
-  background: #f5f5f5;
+  background: #f4f4f4;
   color: #111111;
 }
 
@@ -116,9 +116,9 @@ body.darkCode .hljs-deletion {
 /* Koji doc specific changes */
 
 body.darkCode code {
-  background-color: #f5f5f5;
+  background-color: #f4f4f4;
   color: #111111;
-  border-color: #f5f5f5;
+  border-color: #f4f4f4;
   border-radius: 2.5px;
 }
 
@@ -128,7 +128,6 @@ body.darkCode .hljs .lineNum:after {
 
 body.darkCode .listingblock pre button, body.darkCode .lang-indicator {
   color: #888888;
-  font-weight: bold !important;
 }
 
 body.darkCode .listingblock pre button:after {
@@ -138,27 +137,17 @@ body.darkCode .listingblock pre button:after {
 body.darkCode .tabbed .tabbed__toggle {
   color: #666666;
   background-color: rgba(0, 0, 0, 0.05);
-  border-color: rgba(0, 0, 0, 0.05);
   opacity: 0.7;
 }
 
 body.darkCode .tabbed .tabbed__toggle.tabbed__toggle_active, body.darkCode .tabbed .tabbed__toggle.tabbed__toggle_active:after {
-  background-color: #f5f5f5;
-  border-color: #f5f5f5;
-  color: #666666;
+  background-color: #f4f4f4;
+  color: #111111;
   opacity: 1;
 }
 
-body.darkCode .tabbed .tabbed .tabbed__toggle.tabbed__toggle_active, body.darkCode .tabbed .tabbed .tabbed__toggle:hover {
-  border-bottom-color: #666666;
-}
-
-body.darkCode .tabbed .tabs {
-  border-color: #f5f5f5;
-}
-
 body.darkCode .tabbed .tabs .tabbed__tab {
-  background-color: #f5f5f5;
+  background-color: #f4f4f4;
   color: #666666;
 }
 
@@ -167,14 +156,9 @@ body.darkCode .tabbed .tabs .tabbed__tab a {
 }
 
 body.darkCode .tabbed .tabs .tabbed__tab .admonitionblock .content code {
-  background-color: #f5f5f5;
+  background-color: #f4f4f4;
   color: #666666;
-  border-color: #f5f5f5;
   overflow: hidden;
-}
-
-body.darkCode .tabbed .tabs .tabbed__tab .listingblock ~ div:not(.listingblock) {
-  border-top-color: #111111;
 }
 
 body.darkCode code .collapsible:after {

--- a/src/styles/dark-code.css
+++ b/src/styles/dark-code.css
@@ -5,7 +5,7 @@
 
 body.darkCode .hljs {
   background: #f5f5f5;
-  color: #333333;
+  color: #111111;
 }
 
 body.darkCode .hljs-keyword,
@@ -117,7 +117,7 @@ body.darkCode .hljs-deletion {
 
 body.darkCode code {
   background-color: #f5f5f5;
-  color: #333333;
+  color: #111111;
   border-color: #f5f5f5;
   border-radius: 2.5px;
 }
@@ -128,7 +128,7 @@ body.darkCode .hljs .lineNum:after {
 
 body.darkCode .listingblock pre button, body.darkCode .lang-indicator {
   color: #888888;
-  font-weight: 500 !important;
+  font-weight: bold !important;
 }
 
 body.darkCode .listingblock pre button:after {
@@ -174,7 +174,7 @@ body.darkCode .tabbed .tabs .tabbed__tab .admonitionblock .content code {
 }
 
 body.darkCode .tabbed .tabs .tabbed__tab .listingblock ~ div:not(.listingblock) {
-  border-top-color: #333;
+  border-top-color: #111111;
 }
 
 body.darkCode code .collapsible:after {

--- a/src/templates/Asciidoc/components/Content.js
+++ b/src/templates/Asciidoc/components/Content.js
@@ -43,12 +43,12 @@ const Content = styled.div`
   code {
     font-family: Menlo, Monaco, "Liberation Mono", Consolas, monospace;
     font-weight: normal;
-    font-size: 13px;
-    padding: 1px 4px;
+    font-size: 12px;
+    padding: 4px;
     border-radius: 1px;
     transition: max-height 0.4s ease;
     position: relative;
-    background-color: #F8F8F8;
+    background-color: #f4f4f4;
     &.expanded {
       padding-bottom: 50px;
     }
@@ -124,7 +124,7 @@ const Content = styled.div`
       border: none;
       background-color: transparent;
       color: #111111;
-      font-size: 20px;
+      font-size: 16px;
       cursor: pointer;
       &:hover {
         color: #999;
@@ -186,7 +186,7 @@ const Content = styled.div`
   }
 
   pre, pre > code {
-    line-height: 1.6;
+    line-height: 1.5;
     margin: 0;
     position: relative;
   }
@@ -200,10 +200,12 @@ const Content = styled.div`
     text-transform: uppercase;
     display: block;
     position: absolute;
-    top: 6px;
-    right: 42px;
+    top: 8px;
+    right: 36px;
     opacity: 0.6;
     z-index: 12;
+    font-size: 11px;
+    font-weight: normal!important;
     &:before {
       content: attr(data-language);
     }
@@ -239,8 +241,8 @@ const Content = styled.div`
   h1 {
     margin-top: 0;
     line-height: 1;
-    font-size: 2.5rem;
-    font-weight: 800;
+    font-size: 2.3rem;
+    font-weight: bold;
   }
 
   h2 {
@@ -283,23 +285,21 @@ const Content = styled.div`
   }
 
   .tabbed__toggle {
-    border: 1px solid #AAA;
-    border-bottom: none;
     padding: 5px 12px;
     display: inline-block;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
     cursor: pointer;
     background-color: #DDD;
     position: relative;
     user-select: none;
     z-index: 10;
     font-weight: bold;
-    margin-right: 5px;
-    font-size: 16px;
+    font-size: 11px;
+    text-transform: uppercase;
+
     &.tabbed__toggle_active, &:hover {
       background-color: rgb(248,248,248);
     }
+
     &.tabbed__toggle_active:after {
       content: '';
       position: absolute;
@@ -325,7 +325,6 @@ const Content = styled.div`
   }
 
   .tabs {
-    border: 1px solid #AAA;
     position: relative;
     border-radius: 0 4px 4px 4px;
     &:after {

--- a/src/templates/Asciidoc/components/Content.js
+++ b/src/templates/Asciidoc/components/Content.js
@@ -36,10 +36,8 @@ const Content = styled.div`
   }
 
   p, body {
-    font-size: 16px !important;
-    line-height: 21px;
-    word-spacing: 0.04em;
-    letter-spacing: 0.01em;
+    font-size: 15px !important;
+    line-height: 22px;
   }
 
   code {
@@ -109,7 +107,7 @@ const Content = styled.div`
       user-select: none;
       content: ' ' attr(data-line-number) ' | ';
       opacity: 0.5;
-      color: #333;
+      color: #111111;
     }
     &:before {
       display: none;
@@ -125,7 +123,7 @@ const Content = styled.div`
       top: 5px;
       border: none;
       background-color: transparent;
-      color: #333;
+      color: #111111;
       font-size: 20px;
       cursor: pointer;
       &:hover {
@@ -140,7 +138,7 @@ const Content = styled.div`
         top: 100%;
         left: 50%;
         transform: translateX(-50%);
-        background-color: #333;
+        background-color: #111111;
         font-size: 12px;
         color: #DCDCDC;
         padding: 3px 5px;
@@ -157,7 +155,7 @@ const Content = styled.div`
       right: 5px;
       transition: 0.2s ease-in-out;
       &:after {
-        color: #333;
+        color: #111111;
         content: '\f00c';
         font-weight: 900;
         font-family: "Font Awesome 5 Free";
@@ -241,20 +239,20 @@ const Content = styled.div`
   h1 {
     margin-top: 0;
     line-height: 1;
-    font-size: 2.125em;
-    font-weight: 500;
+    font-size: 2.5rem;
+    font-weight: 800;
   }
 
   h2 {
     font-size: 1.6875em;
     margin-top: 1.9em;
-    font-weight: 400;
+    font-weight: bold;
   }
 
   h3 {
     font-size: 1.375em;
     margin-top: 1.2em;
-    font-weight: 400;
+    font-weight: bold;
   }
 
   h4 {


### PR DESCRIPTION
A few more design nitpicks to carry on Diddy's work from earlier. Just generally tightened a few things up (colors, fonts, letter spacing) to bring things in line with Platform design.

Content changes:
- I removed the icons for TIP/etc. as they felt dated - we should bring them back as soon as we have a design resource to design some consistent icons.
- Ditto for the Koji development process graphic. I think the graphic itself communicates very well, but the visual design should be cleaned up, considering it is the first thing people see when they show up here. @rasienko we should coordinate with Steve to make sure that we get designer attention on the graphics, screenshots, and videos in the documentation content moving forward.

This is ready to go if you're happy with it!