### PR TITLE
DC-618 Deprecate VCC topic and its children

### DIFF
--- a/src/asciidoc/docs/customizations/array.adoc
+++ b/src/asciidoc/docs/customizations/array.adoc
@@ -1,4 +1,4 @@
-= Array (composition)
+= Array (composition) (deprecated)
 :page-slug: array
 :page-description: Composition control for creating a list values with a single VCC definition.
 

--- a/src/asciidoc/docs/customizations/boolean.adoc
+++ b/src/asciidoc/docs/customizations/boolean.adoc
@@ -1,4 +1,4 @@
-= Boolean
+= Boolean (deprecated)
 :page-slug: boolean
 :page-description: Standard VCC for toggling a Boolean value on or off (true or false).
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/color.adoc
+++ b/src/asciidoc/docs/customizations/color.adoc
@@ -1,4 +1,4 @@
-= Color
+= Color (deprecated)
 :page-slug: color
 :page-description: Standard VCCs for selecting a color.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/coordinate.adoc
+++ b/src/asciidoc/docs/customizations/coordinate.adoc
@@ -1,4 +1,4 @@
-= Coordinate
+= Coordinate (deprecated)
 :page-slug: coordinate
 :page-description: Standard VCC for specifying a coordinate pair (x,y).
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/file.adoc
+++ b/src/asciidoc/docs/customizations/file.adoc
@@ -1,4 +1,4 @@
-= File
+= File (deprecated)
 :page-slug: file
 :page-description: Standard VCC for uploading a file.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/googleFont.adoc
+++ b/src/asciidoc/docs/customizations/googleFont.adoc
@@ -1,4 +1,4 @@
-= Google Font
+= Google Font (deprecated)
 :page-slug: google-font
 :page-description: Custom VCC for selecting a font family from Google Fonts.
 

--- a/src/asciidoc/docs/customizations/image.adoc
+++ b/src/asciidoc/docs/customizations/image.adoc
@@ -1,4 +1,4 @@
-= Image
+= Image (deprecated)
 :page-slug: image
 :page-description: Standard VCC for selecting an image.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/link.adoc
+++ b/src/asciidoc/docs/customizations/link.adoc
@@ -1,4 +1,4 @@
-= Link
+= Link (deprecated)
 :page-slug: link-vcc
 :page-description: Standard VCC for selecting or creating a Koji from another Koji or pasting content from a link.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/media.adoc
+++ b/src/asciidoc/docs/customizations/media.adoc
@@ -1,4 +1,4 @@
-= Media
+= Media (deprecated)
 :page-slug: media
 :page-description: Standard VCC for selecting an image, file, sound, or video.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/object.adoc
+++ b/src/asciidoc/docs/customizations/object.adoc
@@ -1,4 +1,4 @@
-= Object (composition)
+= Object (composition) (deprecated)
 :page-slug: object
 :page-description: Composition control for defining an object that is composed of multiple VCCs.
 

--- a/src/asciidoc/docs/customizations/overview.adoc
+++ b/src/asciidoc/docs/customizations/overview.adoc
@@ -1,7 +1,10 @@
-= Visual Customization Controls
+= Visual Customization Controls (deprecated)
 :page-slug: vcc-overview
 :page-description: How to use Visual Customization Controls for remixable elements in your Koji templates.
 :figure-caption!:
+
+IMPORTANT: Visual Customization Controls (VCCs) are deprecated and are included only for backwards compatibility.
+Use the <<core-frontend-ui-capture#,Frontend UI/Capture>> component of the @withkoji/core package instead.
 
 Visual Customization Controls (VCCs) enable users to quickly edit elements of your template on Koji.
 The control types and default values are defined in JSON files in your project.

--- a/src/asciidoc/docs/customizations/range.adoc
+++ b/src/asciidoc/docs/customizations/range.adoc
@@ -1,4 +1,4 @@
-= Range
+= Range (deprecated)
 :page-slug: range
 :page-description: Standard VCC for selecting a numeric value within a certain range.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/secret.adoc
+++ b/src/asciidoc/docs/customizations/secret.adoc
@@ -1,4 +1,4 @@
-= Secret
+= Secret (deprecated)
 :page-slug: secret
 :page-description: Standard VCC for storing sensitive data in any VCC type in a Koji project.
 

--- a/src/asciidoc/docs/customizations/select.adoc
+++ b/src/asciidoc/docs/customizations/select.adoc
@@ -1,4 +1,4 @@
-= Select
+= Select (deprecated)
 :page-slug: select
 :page-description: Standard VCC for making a selection from a predefined list of options.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/size.adoc
+++ b/src/asciidoc/docs/customizations/size.adoc
@@ -1,4 +1,4 @@
-= Size
+= Size (deprecated)
 :page-slug: size
 :page-description: Standard VCC for specifying a (width, height) pair.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/sound.adoc
+++ b/src/asciidoc/docs/customizations/sound.adoc
@@ -1,4 +1,4 @@
-= Sound
+= Sound (deprecated)
 :page-slug: sound
 :page-description: Standard VCC for selecting a sound.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/text.adoc
+++ b/src/asciidoc/docs/customizations/text.adoc
@@ -1,4 +1,4 @@
-= Text, textarea
+= Text, textarea (deprecated)
 :page-slug: text
 :page-description: Standard VCCs for entering custom text.
 :figure-caption!:

--- a/src/asciidoc/docs/customizations/video.adoc
+++ b/src/asciidoc/docs/customizations/video.adoc
@@ -1,4 +1,5 @@
-= Video
+= Video (deprecated)
+
 :page-slug: video
 :page-description: Standard VCC for uploading video files with automatic transcoding and formatting.
 :figure-caption!:

--- a/src/nav.json
+++ b/src/nav.json
@@ -88,7 +88,7 @@
           "root": "/customizations",
           "items": [
             {
-              "name": "Visual Customization Controls",
+              "name": "Visual Customization Controls (deprecated)",
               "slug": "vcc-overview",
               "subItems": [
                 {


### PR DESCRIPTION
* Added "(deprecated)" to the titles of each topic.
* In nav.json, added "(deprecated)" to the title of the overview page only.
* Added an important note in the overview to direct readers to the UI/Capture topic under References.