### PR TITLE
Fix initialTransform broken link

### DIFF
--- a/src/asciidoc/docs/develop/app-dev-process.adoc
+++ b/src/asciidoc/docs/develop/app-dev-process.adoc
@@ -53,7 +53,7 @@ Learn more: <<projects#_develop, develop key>>, <<projects#_deploy, deploy key>>
 
 . If the app has customization options for creators, define the default values for those options and any placeholder values for new customized versions.
 +
-Learn more: <<projects#_remixData, remixData key>>, <<projects#_@@initialTransform, @@initialTransform key>>
+Learn more: <<projects#_remixdata, remixData key>>, <<projects#_initialtransform, @@initialTransform key>>
 
 . Configure the entitlements for the Koji platform features in your app.
 +


### PR DESCRIPTION
- initialTransform link was leading to a 404, this PR fixes that.
[Preview link](https://developer.withkoji.com/docs/develop/app-dev-process#_define_configuration_data)

- initialTransform and remixData links were not scrolling to their respective sections on project page because id generated by gatsby are not camel cased. Removing camel case on the links fixes the issue.

| Bug Preview | Bug Fix  |
| :---:   | :-: |
|![link-bug](https://user-images.githubusercontent.com/32850166/173897258-d8d9b62e-630d-4389-871d-7f7dc548d031.gif) |![link-fix](https://user-images.githubusercontent.com/32850166/173897420-6f0ec2dd-23bc-4b6c-a190-4b6a0368d247.gif) |